### PR TITLE
ci: add GitHub workflow for OpenAI Issue Labeler

### DIFF
--- a/.github/workflows/gpt-issue-labeler.yml
+++ b/.github/workflows/gpt-issue-labeler.yml
@@ -1,0 +1,12 @@
+name: "OpenAI Issue Labeler"
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: austenstone/openai-issue-labeler@v2
+        with:
+          openai-api-key: "${{ secrets.OPENAI_API_KEY }}"


### PR DESCRIPTION
- Add a new Github workflow file for the OpenAI Issue Labeler
- The workflow triggers on opened and edited issues
- The workflow runs on the latest Ubuntu version
- The workflow step uses the `austenstone/openai-issue-labeler` action
- The action requires the `OPENAI_API_KEY` secret to be set

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Fixes #\<issue_number>

## Before submitting

- [ ] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
